### PR TITLE
Fixed error in forward method of CausalConvTran, also fixed name typo

### DIFF
--- a/Models/model.py
+++ b/Models/model.py
@@ -17,7 +17,7 @@ def model_factory(config):
     if config['Net_Type'][0] == 'T':
         model = Transformer(config, num_classes=config['num_labels'])
     elif config['Net_Type'][0] == 'CC-T':
-        model = CasualConvTran(config, num_classes=config['num_labels'])
+        model = CausalConvTran(config, num_classes=config['num_labels'])
     else:
         model = ConvTran(config, num_classes=config['num_labels'])
     return model
@@ -150,7 +150,7 @@ class ConvTran(nn.Module):
         return out
 
 
-class CasualConvTran(nn.Module):
+class CausalConvTran(nn.Module):
     def __init__(self, config, num_classes):
         super().__init__()
         # Parameters Initialization -----------------------------------------------
@@ -200,8 +200,8 @@ class CasualConvTran(nn.Module):
 
     def forward(self, x):
         x = x.unsqueeze(1)
-        x_src = self.embed_layer(x)
-        x_src = self.embed_layer2(x_src).squeeze(2)
+        x_src = self.causal_Conv1(x)
+        x_src = self.causal_Conv3(x_src).squeeze(2)
         x_src = x_src.permute(0, 2, 1)
         if self.Fix_pos_encode != 'None':
             x_src_pos = self.Fix_Position(x_src)

--- a/Models/model.py
+++ b/Models/model.py
@@ -201,6 +201,7 @@ class CausalConvTran(nn.Module):
     def forward(self, x):
         x = x.unsqueeze(1)
         x_src = self.causal_Conv1(x)
+        x_src = self.causal_Conv2(x_src)
         x_src = self.causal_Conv3(x_src).squeeze(2)
         x_src = x_src.permute(0, 2, 1)
         if self.Fix_pos_encode != 'None':


### PR DESCRIPTION
- The `CausalConvTran` model in `model.py` used `self.embed_layer` and `self.embed_layer2`, but these layers have not been defined in the `__init__` method of this class. Replaced these methods with the correct layer names already defined - `causal_Conv1` and `causal_Conv2`.
- There was a typo in the name of this class, it was earlier named `CasualConvTran`, changed it to `CausalConvTran`.